### PR TITLE
Feature/split version source

### DIFF
--- a/src/alphadb/Cargo.toml
+++ b/src/alphadb/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 default = []
 mysql = ["dep:mysql"]
 postgres = ["dep:postgres"]
+version-source = []
 
 [dependencies]
 mysql = { version = "25.0.1", optional = true }

--- a/src/alphadb/src/core/utils/version_number.rs
+++ b/src/alphadb/src/core/utils/version_number.rs
@@ -28,7 +28,7 @@ use crate::core::{utils::errors::AlphaDBError, verification::issue::VersionTrace
 /// # Errors
 /// * Returns `AlphaDBError` if the version number is invalid
 pub fn validate_version_number(version_number: &str) -> Result<bool, AlphaDBError> {
-    match version_number.replace(".", ",").parse::<u32>() {
+    match version_number.replace(".", "").parse::<u32>() {
         Ok(_) => Ok(true),
         Err(_) => Err(AlphaDBError {
             message: format!("'{}' is not a valid version number", version_number),

--- a/src/alphadb/src/engine/mod.rs
+++ b/src/alphadb/src/engine/mod.rs
@@ -4,6 +4,7 @@
 pub mod mysql_impl;
 
 use core::fmt;
+use std::str::FromStr;
 
 #[cfg(feature = "mysql")]
 pub use mysql_impl::mysql_runtime_config as mysql;
@@ -13,6 +14,8 @@ pub mod postgres_impl;
 
 #[cfg(feature = "postgres")]
 pub use postgres_impl::postgres_runtime_config as postgres;
+
+use crate::{core::utils::errors::AlphaDBError, verification::VersionTrace};
 
 /// Supported AlphaDB database engines
 pub enum AlphaDBEngine {
@@ -28,5 +31,21 @@ impl fmt::Display for AlphaDBEngine {
         };
 
         write!(f, "{engine}")
+    }
+}
+
+impl FromStr for AlphaDBEngine {
+    type Err = AlphaDBError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "postgres" => Ok(AlphaDBEngine::PostgreSQL),
+            "mysql" => Ok(AlphaDBEngine::MySQL),
+            _ => Err(AlphaDBError {
+                message: format!("\"{s}\" is not a supported AlphaDB engine (expected one of: postgres, mysql)"),
+                error: "unsupported-engine".to_string(),
+                version_trace: VersionTrace::new(),
+            }),
+        }
     }
 }

--- a/src/alphadb/src/engine/mod.rs
+++ b/src/alphadb/src/engine/mod.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "mysql")]
 pub mod mysql_impl;
 
+use core::fmt;
+
 #[cfg(feature = "mysql")]
 pub use mysql_impl::mysql_runtime_config as mysql;
 
@@ -11,3 +13,20 @@ pub mod postgres_impl;
 
 #[cfg(feature = "postgres")]
 pub use postgres_impl::postgres_runtime_config as postgres;
+
+/// Supported AlphaDB database engines
+pub enum AlphaDBEngine {
+    PostgreSQL,
+    MySQL,
+}
+
+impl fmt::Display for AlphaDBEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let engine = match self {
+            AlphaDBEngine::PostgreSQL => "postgres",
+            AlphaDBEngine::MySQL => "mysql",
+        };
+
+        write!(f, "{engine}")
+    }
+}

--- a/src/alphadb/src/lib.rs
+++ b/src/alphadb/src/lib.rs
@@ -16,6 +16,8 @@ pub mod core;
 pub mod engine;
 pub mod prelude;
 pub mod verification;
+#[cfg(feature = "version-source")]
+pub mod version_source;
 
 use crate::core::{
     method_types::{Init, Query, Status},

--- a/src/alphadb/src/version_source/combine.rs
+++ b/src/alphadb/src/version_source/combine.rs
@@ -20,8 +20,7 @@ use std::str::FromStr;
 use serde_json::{Map, Value};
 
 use crate::core::utils::errors::AlphaDBError;
-use crate::core::utils::version_number::{parse_version_number, validate_version_number};
-use crate::core::utils::version_source::{get_version_array, parse_version_source_string};
+use crate::core::utils::version_number::validate_version_number;
 use crate::engine::AlphaDBEngine;
 use crate::verification::VersionTrace;
 
@@ -57,10 +56,9 @@ pub fn combine_version_source_files(files: &[PathBuf], name: String, engine: Alp
             Err(_) => panic!("An error occured while opening the version source file!"),
         };
 
-        let parsed = parse_version_source_string(file_contents)?;
-        let versions = get_version_array(&parsed)?;
+        let parsed: serde_json::Value = serde_json::from_str(&file_contents)?;
 
-        combined_versions.extend(versions.iter().cloned());
+        combined_versions.push(parsed);
     }
 
     let mut root = Map::new();
@@ -68,8 +66,6 @@ pub fn combine_version_source_files(files: &[PathBuf], name: String, engine: Alp
     root.insert("name".to_string(), Value::String(name));
     root.insert("engine".to_string(), Value::String(engine.to_string()));
     root.insert("version".to_string(), Value::Array(combined_versions));
-
-    println!("{:?}", root);
 
     Ok(Value::Object(root))
 }

--- a/src/alphadb/src/version_source/combine.rs
+++ b/src/alphadb/src/version_source/combine.rs
@@ -39,7 +39,7 @@ use crate::verification::VersionTrace;
 /// # Errors
 /// * Returns `AlphaDBError` if any of the provided strings cannot be
 ///   deserialized or does not contain a valid version array.
-pub fn combine_version_source_files(files: &[PathBuf], name: String, engine: AlphaDBEngine) -> Result<Value, AlphaDBError> {
+pub fn combine_version_source_files(files: &[(String, PathBuf)], name: String, engine: AlphaDBEngine) -> Result<Value, AlphaDBError> {
     if files.is_empty() {
         return Err(AlphaDBError {
             message: "No version source files were provided. At least one version source is required to build a combined version source.".to_string(),
@@ -48,24 +48,40 @@ pub fn combine_version_source_files(files: &[PathBuf], name: String, engine: Alp
         });
     }
 
-    let mut combined_versions: Vec<Value> = Vec::new();
+    let mut version: Vec<Value> = Vec::new();
 
     for file in files {
-        let file_contents = match fs::read_to_string(file) {
+        let file_contents = match fs::read_to_string(&file.1) {
             Ok(f) => f,
             Err(_) => panic!("An error occured while opening the version source file!"),
         };
 
-        let parsed: serde_json::Value = serde_json::from_str(&file_contents)?;
+        let mut parsed: serde_json::Value = serde_json::from_str(&file_contents)?;
 
-        combined_versions.push(parsed);
+        let parsed_map = match parsed.as_object_mut() {
+            Some(map) => map,
+            None => {
+                return Err(AlphaDBError {
+                    message: format!(
+                        "The version source file \"{}\" does not contain a JSON object. Each version source file must define a JSON object keyed by method names.",
+                        file.1.display()
+                    ),
+                    error: "version-source-not-an-object".to_string(),
+                    version_trace: VersionTrace::new(),
+                })
+            }
+        };
+
+        parsed_map.insert("_id".to_string(), Value::String(file.0.clone()));
+        version.push(parsed);
     }
 
     let mut root = Map::new();
 
     root.insert("name".to_string(), Value::String(name));
     root.insert("engine".to_string(), Value::String(engine.to_string()));
-    root.insert("version".to_string(), Value::Array(combined_versions));
+
+    root.insert("version".to_string(), Value::Array(version));
 
     Ok(Value::Object(root))
 }
@@ -112,7 +128,7 @@ const ALLOWED_CONFIG_FILENAMES: [&str; 2] = ["adb-config.json", "_adb-config.jso
 
 pub struct VersionSourceParts {
     config: VersionSourceConfig,
-    files: Vec<PathBuf>,
+    files: Vec<(String, PathBuf)>,
 }
 
 pub fn gather_version_source_files(path: &PathBuf) -> Result<VersionSourceParts, AlphaDBError> {
@@ -162,7 +178,7 @@ pub fn gather_version_source_files(path: &PathBuf) -> Result<VersionSourceParts,
         }
     };
 
-    let mut file_paths: Vec<PathBuf> = Vec::new();
+    let mut file_paths: Vec<(String, PathBuf)> = Vec::new();
     for file in dir_contents {
         let file = match file {
             Ok(f) => f,
@@ -181,8 +197,12 @@ pub fn gather_version_source_files(path: &PathBuf) -> Result<VersionSourceParts,
             }
 
             // Check if valid version number is present in filename
-            match filename.split("-").next() {
-                Some(rv) => validate_version_number(rv)?,
+            let version = match filename.split("-").next() {
+                Some(rv) => {
+                    validate_version_number(rv)?;
+
+                    rv
+                }
                 None => {
                     return Err(AlphaDBError {
                         message: format!(
@@ -195,7 +215,7 @@ pub fn gather_version_source_files(path: &PathBuf) -> Result<VersionSourceParts,
                 }
             };
 
-            file_paths.push(path.join(filename));
+            file_paths.push((version.to_string(), path.join(filename)));
         }
     }
 

--- a/src/alphadb/src/version_source/combine.rs
+++ b/src/alphadb/src/version_source/combine.rs
@@ -1,0 +1,214 @@
+// Copyright (C) 2024 Wibo Kuipers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde_json::{Map, Value};
+
+use crate::core::utils::errors::AlphaDBError;
+use crate::core::utils::version_number::{parse_version_number, validate_version_number};
+use crate::core::utils::version_source::{get_version_array, parse_version_source_string};
+use crate::engine::AlphaDBEngine;
+use crate::verification::VersionTrace;
+
+/// Combine multiple separate version sources into a single version source.
+///
+/// The versions of each source are concatenated in the order they are
+/// provided. The `name` of the resulting version source is taken from the
+/// first source that defines one.
+///
+/// # Arguments
+/// * `version_sources` - Slice of version source strings (JSON)
+///
+/// # Returns
+/// * `Result<Value, AlphaDBError>` - Combined version source as a JSON Value
+///
+/// # Errors
+/// * Returns `AlphaDBError` if any of the provided strings cannot be
+///   deserialized or does not contain a valid version array.
+pub fn combine_version_source_files(files: &[PathBuf], name: String, engine: AlphaDBEngine) -> Result<Value, AlphaDBError> {
+    if files.is_empty() {
+        return Err(AlphaDBError {
+            message: "No version source files were provided. At least one version source is required to build a combined version source.".to_string(),
+            error: "no-version-source-files-provided".to_string(),
+            version_trace: VersionTrace::new(),
+        });
+    }
+
+    let mut combined_versions: Vec<Value> = Vec::new();
+
+    for file in files {
+        let file_contents = match fs::read_to_string(file) {
+            Ok(f) => f,
+            Err(_) => panic!("An error occured while opening the version source file!"),
+        };
+
+        let parsed = parse_version_source_string(file_contents)?;
+        let versions = get_version_array(&parsed)?;
+
+        combined_versions.extend(versions.iter().cloned());
+    }
+
+    let mut root = Map::new();
+
+    root.insert("name".to_string(), Value::String(name));
+    root.insert("engine".to_string(), Value::String(engine.to_string()));
+    root.insert("version".to_string(), Value::Array(combined_versions));
+
+    println!("{:?}", root);
+
+    Ok(Value::Object(root))
+}
+
+struct VersionSourceConfig {
+    name: String,
+    engine: AlphaDBEngine,
+}
+
+fn parse_config_file(path: &PathBuf) -> Result<VersionSourceConfig, AlphaDBError> {
+    let file_contents = match fs::read_to_string(path) {
+        Ok(f) => f,
+        Err(_) => panic!("An error occured while opening the version source file!"),
+    };
+
+    let contents: serde_json::Value = serde_json::from_str(&file_contents)?;
+
+    let name = match contents["name"].as_str() {
+        Some(n) => n.to_string(),
+        None => {
+            return Err(AlphaDBError {
+                message: "Name not defined".to_string(),
+                error: "name-not-defined".to_string(),
+                version_trace: VersionTrace::new(),
+            })
+        }
+    };
+
+    let engine = match contents["engine"].as_str() {
+        Some(n) => AlphaDBEngine::from_str(n)?,
+        None => {
+            return Err(AlphaDBError {
+                message: "Name not defined".to_string(),
+                error: "name-not-defined".to_string(),
+                version_trace: VersionTrace::new(),
+            })
+        }
+    };
+
+    Ok(VersionSourceConfig { name, engine })
+}
+
+const ALLOWED_CONFIG_FILENAMES: [&str; 2] = ["adb-config.json", "_adb-config.json"];
+
+pub struct VersionSourceParts {
+    config: VersionSourceConfig,
+    files: Vec<PathBuf>,
+}
+
+pub fn gather_version_source_files(path: &PathBuf) -> Result<VersionSourceParts, AlphaDBError> {
+    let mut found_config_files: Vec<&str> = Vec::new();
+    for filename in ALLOWED_CONFIG_FILENAMES {
+        if Path::exists(&path.join(filename)) {
+            found_config_files.push(filename);
+        }
+    }
+
+    let config_file_name = match found_config_files.len() {
+        0 => {
+            return Err(AlphaDBError {
+                message: format!(
+                    "No version config file was found in the specified directory ({}). Expected one of: {}",
+                    path.display(),
+                    ALLOWED_CONFIG_FILENAMES.join(", ")
+                ),
+                error: "no-config-file-found".to_string(),
+                version_trace: VersionTrace::new(),
+            })
+        }
+        1 => found_config_files[0],
+        _ => {
+            return Err(AlphaDBError {
+                message: format!(
+                    "Multiple config files were found in the specified directory ({}). Exactly one is required, but found: {}",
+                    path.display(),
+                    found_config_files.join(", ")
+                ),
+                error: "multiple-config-files-found".to_string(),
+                version_trace: VersionTrace::new(),
+            })
+        }
+    };
+
+    let config = parse_config_file(&path.join(config_file_name))?;
+
+    let dir_contents = match fs::read_dir(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(AlphaDBError {
+                message: format!("Failed to read the specified directory ({}): {}", path.display(), e),
+                error: "directory-read-failed".to_string(),
+                version_trace: VersionTrace::new(),
+            })
+        }
+    };
+
+    let mut file_paths: Vec<PathBuf> = Vec::new();
+    for file in dir_contents {
+        let file = match file {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(AlphaDBError {
+                    message: format!("Failed to read a directory entry in {}: {}", path.display(), e),
+                    error: "directory-entry-read-failed".to_string(),
+                    version_trace: VersionTrace::new(),
+                })
+            }
+        };
+
+        if let Some(filename) = file.file_name().to_str() {
+            if filename == config_file_name {
+                continue;
+            }
+
+            // Check if valid version number is present in filename
+            match filename.split("-").next() {
+                Some(rv) => validate_version_number(rv)?,
+                None => {
+                    return Err(AlphaDBError {
+                        message: format!(
+                            "The version number could not be parsed from the file name \"{}\". The file name must start with a version number followed by a hyphen.",
+                            filename
+                        ),
+                        error: "version-number-parse-failed".to_string(),
+                        version_trace: VersionTrace::new(),
+                    })
+                }
+            };
+
+            file_paths.push(path.join(filename));
+        }
+    }
+
+    Ok(VersionSourceParts { config, files: file_paths })
+}
+
+pub fn build_version_source_from_dir(path: &PathBuf) -> Result<Value, AlphaDBError> {
+    let parts = gather_version_source_files(path)?;
+    let combined = combine_version_source_files(&parts.files, parts.config.name, parts.config.engine)?;
+
+    Ok(combined)
+}

--- a/src/alphadb/src/version_source/mod.rs
+++ b/src/alphadb/src/version_source/mod.rs
@@ -1,3 +1,3 @@
 mod combine;
 
-pub use combine::{combine_version_source_files, gather_version_source_files};
+pub use combine::{build_version_source_from_dir, combine_version_source_files, gather_version_source_files};

--- a/src/alphadb/src/version_source/mod.rs
+++ b/src/alphadb/src/version_source/mod.rs
@@ -1,0 +1,3 @@
+mod combine;
+
+pub use combine::{combine_version_source_files, gather_version_source_files};


### PR DESCRIPTION
This adds an optional crate feature "version-source" which exposes utilities for building a version source from a directory structure of files. These files represent a single version in the version source.